### PR TITLE
Additional aws credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,20 @@ gem install cloudwatch-sender
 ### Command Line
 
 ```sh
-cloudwatch-sender send_metrics /path/to/config.yaml $AWS_ACCESS_KEY $AWS_SECRET_KEY $AWS_REGION
+cloudwatch-sender send_metrics /path/to/config.yaml --region=eu-west-1 --access-key-id=$AWS_ACCESS_KEY --secret-access-key= $AWS_SECRET_KEY
 ```
 
 If you would like to stream metrics to your endpoint at a set interval, use `continuous`:
 
 ```sh
-cloudwatch-sender continuous /path/to/config.yaml $AWS_ACCESS_KEY $AWS_SECRET_KEY $AWS_REGION $INTERVAL
+cloudwatch-sender continuous /path/to/config.yaml --region=eu-west-1 $INTERVAL --access-key-id=$AWS_ACCESS_KEY --secret-access-key= $AWS_SECRET_KEY
 ```
 
 **Note** - the default `$INTERVAL` is 60 seconds.
+
+```sh
+cloudwatch-sender continuous /path/to/config.yaml --region=eu-west-1 $INTERVAL --provider=iam
+```
 
 ### Programmatically
 
@@ -54,7 +58,7 @@ cloudwatch-sender continuous /path/to/config.yaml $AWS_ACCESS_KEY $AWS_SECRET_KE
 require "cloudwatch/sender/cli"
 
 loop do
-  Cloudwatch::Sender::CLI.new.send_metrics(config_path, key_id, access_key, region)
+  Cloudwatch::Sender::CLI.new.send_metrics(config_path = './configs/default.yml', { 'region' => 'eu-west-1', 'provider' => 'iam'})
   sleep 120
 end
 ```
@@ -62,7 +66,7 @@ end
 ```ruby
 require "cloudwatch/sender/cli"
 
-Cloudwatch::Sender::CLI.new.continuous(config_path, key_id, access_key, region, sleep_time)
+Cloudwatch::Sender::CLI.new.continuous(config_path = './configs/default.yml', 60, { 'region' => 'eu-west-1', 'provider' => 'iam'})
 ```
 
 ## Configs

--- a/lib/cloudwatch/sender/base.rb
+++ b/lib/cloudwatch/sender/base.rb
@@ -10,6 +10,7 @@ module Cloudwatch
       end
 
       def send_tcp(contents)
+        puts "#{influx_server}:#{influx_port} - #{contents.to_s}" if ENV['DEBUG']
         sock = TCPSocket.open(influx_server, influx_port)
         sock.print contents
       rescue StandardError => e

--- a/lib/cloudwatch/sender/base.rb
+++ b/lib/cloudwatch/sender/base.rb
@@ -10,7 +10,7 @@ module Cloudwatch
       end
 
       def send_tcp(contents)
-        puts "#{influx_server}:#{influx_port} - #{contents.to_s}" if ENV['DEBUG']
+        puts "#{influx_server}:#{influx_port} - #{contents}" if ENV['DEBUG']
         sock = TCPSocket.open(influx_server, influx_port)
         sock.print contents
       rescue StandardError => e

--- a/lib/cloudwatch/sender/cli.rb
+++ b/lib/cloudwatch/sender/cli.rb
@@ -13,7 +13,7 @@ module Cloudwatch
     class CLI < Thor
       include Thor::Actions
 
-      class_option :provider, :desc => 'AWS security provider', :required => false
+      class_option :provider, :desc => 'AWS security provider', :required => false, :enum => ['iam','instance_profile']
       class_option :access_key_id, :desc => 'AWS access_key_id', :required => false
       class_option :secret_access_key, :desc => 'AWS secret_key_id', :required => false
       class_option :region, :desc => 'AWS region', :required => false

--- a/lib/cloudwatch/sender/cli.rb
+++ b/lib/cloudwatch/sender/cli.rb
@@ -63,6 +63,7 @@ module Cloudwatch
             if (options['access_key_id'] || options['secret_access_key']) && ( ! options['access_key_id'] || !options['secret_access_key'])
               raise RequiredArgumentMissingError.new("'--access_key_id' and '--secret_access_key' required")
             end
+            credentials = Aws::Credentials.new(options['access_key_id'], options['secret_access_key'])
           end
           Aws.config.update(:region => region = (options['region'] || ENV['AWS_REGION']), :credentials => credentials)
         end

--- a/lib/cloudwatch/sender/cli.rb
+++ b/lib/cloudwatch/sender/cli.rb
@@ -1,11 +1,12 @@
-require "thor"
-require "logger"
-require "cloudwatch/sender/ec2"
-require "cloudwatch/sender/metric_definition"
-require "cloudwatch/sender/fetcher/base"
-require "cloudwatch/sender/fetcher/ec2"
-require "cloudwatch/sender/fetcher/sqs"
-require "cloudwatch/sender/fetcher/custom"
+require 'thor'
+require 'logger'
+require 'cloudwatch/sender/ec2'
+require 'cloudwatch/sender/credentials'
+require 'cloudwatch/sender/metric_definition'
+require 'cloudwatch/sender/fetcher/base'
+require 'cloudwatch/sender/fetcher/ec2'
+require 'cloudwatch/sender/fetcher/sqs'
+require 'cloudwatch/sender/fetcher/custom'
 
 module Cloudwatch
   module Sender
@@ -17,13 +18,13 @@ module Cloudwatch
       class_option :secret_access_key, :desc => 'AWS secret_key_id', :required => false
       class_option :region, :desc => 'AWS region', :required => false
 
-      desc "send_metrics [metrics_file]", "Gets metrics from Cloudwatch and sends them to influx"
+      desc 'send_metrics [metrics_file]', 'Gets metrics from Cloudwatch and sends them to influx'
       def send_metrics(metrics_file, opts = {})
-        setup_aws(options.merge(opts))
+        setup_aws(options.merge(opts), opts['provider'])
         MetricDefinition.metric_type load_metrics(metrics_file)
       end
 
-      desc "continuous [metrics_file] [sleep time]", "Continuously sends metrics to Influx/Cloudwatch"
+      desc 'continuous [metrics_file] [sleep time]', 'Continuously sends metrics to Influx/Cloudwatch'
       def continuous(metrics_file, sleep_time = 60, opts = {})
         logger = Logger.new(STDOUT)
 
@@ -43,29 +44,23 @@ module Cloudwatch
         end
       end
 
+
       no_commands do
         def load_metrics(metrics_file)
           YAML.load(File.open(metrics_file))
         end
 
-        def setup_aws(options)
-          credentials = nil
-          if options['provider']
-            case true
-              when ['iam', 'instance_profile'].include?(options['provider'].downcase)
-                credentials = Aws::InstanceProfileCredentials.new
-              when (options['access_key_id'])
-                credentials = Aws::Credentials.new(options['access_key_id'], options['secret_access_key'])
-              else
-               raise ArgumentError.new("'--provider' invalid argument '#{options['provider']}'")
-            end
+        def setup_aws(options, provider)
+          SetupAwsCredentials.send("#{validate_provider(provider)}".to_sym, options)
+        end
+
+        def validate_provider(provider)
+          return 'access_key_id' if provider.nil?
+          if %w(iam instance_profile).include? provider.downcase
+            provider.downcase
           else
-            if (options['access_key_id'] || options['secret_access_key']) && ( ! options['access_key_id'] || !options['secret_access_key'])
-              raise RequiredArgumentMissingError.new("'--access_key_id' and '--secret_access_key' required")
-            end
-            credentials = Aws::Credentials.new(options['access_key_id'], options['secret_access_key'])
+            fail ArgumentError.new("'--provider' invalid argument '#{options['provider']}'")
           end
-          Aws.config.update(:region => region = (options['region'] || ENV['AWS_REGION']), :credentials => credentials)
         end
       end
     end

--- a/lib/cloudwatch/sender/cli.rb
+++ b/lib/cloudwatch/sender/cli.rb
@@ -15,21 +15,21 @@ module Cloudwatch
       class_option :provider, :desc => 'AWS security provider', :required => false
       class_option :access_key_id, :desc => 'AWS access_key_id', :required => false
       class_option :secret_access_key, :desc => 'AWS secret_key_id', :required => false
-      class_option :region, :desc => 'AWS region', :required => true
+      class_option :region, :desc => 'AWS region', :required => false
 
       desc "send_metrics [metrics_file]", "Gets metrics from Cloudwatch and sends them to influx"
-      def send_metrics(metrics_file)
-        setup_aws(options)
+      def send_metrics(metrics_file, opts = {})
+        setup_aws(options.merge(opts))
         MetricDefinition.metric_type load_metrics(metrics_file)
       end
 
       desc "continuous [metrics_file] [sleep time]", "Continuously sends metrics to Influx/Cloudwatch"
-      def continuous(metrics_file, sleep_time = 60)
+      def continuous(metrics_file, sleep_time = 60, opts = {})
         logger = Logger.new(STDOUT)
 
         loop do
           begin
-            send_metrics(metrics_file)
+            send_metrics(metrics_file, options.merge(opts))
             sleep sleep_time.to_i
           rescue RequiredArgumentMissingError, ArgumentError => e
             logger.error("Required argument invalid or missing '#{e}'")

--- a/lib/cloudwatch/sender/cli.rb
+++ b/lib/cloudwatch/sender/cli.rb
@@ -1,30 +1,30 @@
-require 'thor'
-require 'logger'
-require 'cloudwatch/sender/ec2'
-require 'cloudwatch/sender/credentials'
-require 'cloudwatch/sender/metric_definition'
-require 'cloudwatch/sender/fetcher/base'
-require 'cloudwatch/sender/fetcher/ec2'
-require 'cloudwatch/sender/fetcher/sqs'
-require 'cloudwatch/sender/fetcher/custom'
+require "thor"
+require "logger"
+require "cloudwatch/sender/ec2"
+require "cloudwatch/sender/credentials"
+require "cloudwatch/sender/metric_definition"
+require "cloudwatch/sender/fetcher/base"
+require "cloudwatch/sender/fetcher/ec2"
+require "cloudwatch/sender/fetcher/sqs"
+require "cloudwatch/sender/fetcher/custom"
 
 module Cloudwatch
   module Sender
     class CLI < Thor
       include Thor::Actions
 
-      class_option :provider, :desc => 'AWS security provider', :required => false, :enum => ['iam','instance_profile']
-      class_option :access_key_id, :desc => 'AWS access_key_id', :required => false
-      class_option :secret_access_key, :desc => 'AWS secret_key_id', :required => false
-      class_option :region, :desc => 'AWS region', :required => false
+      class_option :provider, :desc => "AWS security provider", :required => false, :enum => ["iam", "instance_profile"]
+      class_option :access_key_id, :desc => "AWS access_key_id", :required => false
+      class_option :secret_access_key, :desc => "AWS secret_key_id", :required => false
+      class_option :region, :desc => "AWS region", :required => false
 
-      desc 'send_metrics [metrics_file]', 'Gets metrics from Cloudwatch and sends them to influx'
+      desc "send_metrics [metrics_file]", "Gets metrics from Cloudwatch and sends them to influx"
       def send_metrics(metrics_file, opts = {})
-        setup_aws(options.merge(opts), opts['provider'])
+        setup_aws(options.merge(opts), opts["provider"])
         MetricDefinition.metric_type load_metrics(metrics_file)
       end
 
-      desc 'continuous [metrics_file] [sleep time]', 'Continuously sends metrics to Influx/Cloudwatch'
+      desc "continuous [metrics_file] [sleep time]", "Continuously sends metrics to Influx/Cloudwatch"
       def continuous(metrics_file, sleep_time = 60, opts = {})
         logger = Logger.new(STDOUT)
 
@@ -55,7 +55,7 @@ module Cloudwatch
         end
 
         def validate_provider(provider)
-          return 'access_key_id' if provider.nil?
+          return "access_key_id" if provider.nil?
           if %w(iam instance_profile).include? provider.downcase
             provider.downcase
           else

--- a/lib/cloudwatch/sender/credentials.rb
+++ b/lib/cloudwatch/sender/credentials.rb
@@ -1,0 +1,31 @@
+module Cloudwatch
+  module Sender
+    class SetupAwsCredentials
+      def self.iam(options)
+        provider(options)
+      end
+
+      def self.instance_profile(options)
+        provider(options)
+      end
+
+      def self.access_key_id(options)
+        credentials = Aws::Credentials.new(options["access_key_id"], options["secret_access_key"])
+        Aws.config.update(:region => (options["region"] || ENV["AWS_REGION"]), :credentials => credentials)
+      rescue
+puts "XX"
+        RequiredArgumentMissingError.new("'--access_key_id' and '--secret_access_key' required")
+      end
+
+      private
+
+      def self.credentials
+        Aws::InstanceProfileCredentials.new
+      end
+
+      def self.provider(options)
+        Aws.config.update(:region => (options["region"] || ENV["AWS_REGION"]), :credentials => credentials)
+      end
+    end
+  end
+end

--- a/lib/cloudwatch/sender/credentials.rb
+++ b/lib/cloudwatch/sender/credentials.rb
@@ -13,7 +13,6 @@ module Cloudwatch
         credentials = Aws::Credentials.new(options["access_key_id"], options["secret_access_key"])
         Aws.config.update(:region => (options["region"] || ENV["AWS_REGION"]), :credentials => credentials)
       rescue
-puts "XX"
         RequiredArgumentMissingError.new("'--access_key_id' and '--secret_access_key' required")
       end
 


### PR DESCRIPTION
![i2eaqzi](https://cloud.githubusercontent.com/assets/173567/8032330/28eaf63e-0dcd-11e5-9ddc-2dfe549b227f.png)

### Problem

Credentials for AWS keys must be exposed on instances, when I do not have to provide credentials for instances that have AWS Instance Profiles attached to them. Credentials can be removed altogether ***(Improves security)***. Arguments are also passed in fixed form. 

### Solution

Add additional methods for providing security to Aws ruby client, as well as changing the argument fields to accommodate differing credentials #10

More information on using instance profiles can be found here.
http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-usingrole-ec2instance.html

Just to note I did not implement the following, however if necessary can be added if required.
 * http://docs.aws.amazon.com/sdkforruby/api/Aws/SharedCredentials.html
 * http://docs.aws.amazon.com/sdkforruby/api/Aws/AssumeRoleCredentials.html
 * Custom providers.
