### PR TITLE
Resolve - run rubocop on each commit on travis #15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+cache: bundler
+language: ruby
+rvm:
+  - 2.1
+  - 2.2
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
+before_install:
+  - gem update --remote bundler
+  - mkdir build;
+  - git clone https://github.com/BBC-News/rubocop-config.git build/rubocop-config
+install:
+  - bundle install --retry=3
+script:
+  - bundle exec rubocop -c build/rubocop-config/.rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in cloudwatch-sender.gemspec
 gemspec
+
+
+group :test do
+  gem 'rubocop'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in cloudwatch-sender.gemspec
 gemspec
 
-
 group :test do
-  gem 'rubocop'
+  gem "rubocop"
 end


### PR DESCRIPTION
# Problem

Have to ask people to run rubocop which requires them to set it up and may conflict with rubocop setups they already have. I.e: #11
# Solution

Run rubocop on each commit in travis then mark the PR as pass/failure based on the result from rubocop.
- Add travis and rubocop
- Source rubocop config from remote repo
- This does not resolve the existing violations and therefore fails the build (`15 files inspected, 28 offenses detected`)

@see https://travis-ci.org/ajohnstone/cloudwatch-sender/
