### PR TITLE
pass Ruby hash directly

### DIFF
--- a/lib/cloudwatch/sender/cli.rb
+++ b/lib/cloudwatch/sender/cli.rb
@@ -29,6 +29,7 @@ module Cloudwatch
         MetricDefinition.metric_type load_metrics(metrics_file)
       end
 
+
       desc "continuous [metrics_file] [sleep time]", "Continuously sends metrics to Influx/Cloudwatch"
       def continuous(metrics_file, sleep_time = 60, opts = {})
         logger = Logger.new(STDOUT)
@@ -65,6 +66,11 @@ module Cloudwatch
           else
             fail ArgumentError.new("'--provider' invalid argument '#{options['provider']}'")
           end
+        end
+
+        def send_metrics_ruby(hash, opts = {})
+          setup_aws(options.merge(opts), opts["provider"])
+          MetricDefinition.metric_type hash
         end
       end
     end

--- a/lib/cloudwatch/sender/cli.rb
+++ b/lib/cloudwatch/sender/cli.rb
@@ -29,7 +29,6 @@ module Cloudwatch
         MetricDefinition.metric_type load_metrics(metrics_file)
       end
 
-
       desc "continuous [metrics_file] [sleep time]", "Continuously sends metrics to Influx/Cloudwatch"
       def continuous(metrics_file, sleep_time = 60, opts = {})
         logger = Logger.new(STDOUT)

--- a/lib/cloudwatch/sender/version.rb
+++ b/lib/cloudwatch/sender/version.rb
@@ -1,5 +1,5 @@
 module Cloudwatch
   module Sender
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
## Problem

A YAML file is required to use programmatically, this method allows for passing a Ruby hash directly.
