### PR TITLE
bug fixes databasename and aws namespace

### DIFF
--- a/lib/cloudwatch/sender/base.rb
+++ b/lib/cloudwatch/sender/base.rb
@@ -5,7 +5,7 @@ module Cloudwatch
 
       def initialize(options, metric_prefix)
         @metric_prefix = metric_prefix
-        @influxdb = InfluxDB::Client.new "graphite",
+        @influxdb = InfluxDB::Client.new options["influx_database"] || "graphite",
           :username    => options["influx_username"],
           :password    => options["influx_password"],
           :use_ssl     => options["influx_ssl"] || false,

--- a/lib/cloudwatch/sender/base.rb
+++ b/lib/cloudwatch/sender/base.rb
@@ -5,7 +5,7 @@ module Cloudwatch
 
       def initialize(options, metric_prefix)
         @metric_prefix = metric_prefix
-        @influxdb = InfluxDB::Client.new options["influx_database"] || "graphite",
+        @influxdb = InfluxDB::Client.new options["influx_database"],
           :username    => options["influx_username"],
           :password    => options["influx_password"],
           :use_ssl     => options["influx_ssl"] || false,

--- a/lib/cloudwatch/sender/fetcher/base.rb
+++ b/lib/cloudwatch/sender/fetcher/base.rb
@@ -26,7 +26,7 @@ module Cloudwatch
         end
 
         def fetcher(component_meta)
-          namespace.start_with?("AWS/EC2") || namespace.start_with?("AWS/SQS") ? Object.const_get(class_namespace component_meta) : Cloudwatch::Sender::Fetcher::Custom
+          Object.const_defined?(class_namespace component_meta) ? Object.const_get(class_namespace component_meta) : Cloudwatch::Sender::Fetcher::Custom
         end
 
         def class_namespace(component_meta)

--- a/lib/cloudwatch/sender/fetcher/base.rb
+++ b/lib/cloudwatch/sender/fetcher/base.rb
@@ -26,7 +26,7 @@ module Cloudwatch
         end
 
         def fetcher(component_meta)
-          namespace.start_with?("AWS/") ? Object.const_get(class_namespace component_meta) : Cloudwatch::Sender::Fetcher::Custom
+          namespace.start_with?("AWS/EC2") || namespace.start_with?("AWS/SQS") ? Object.const_get(class_namespace component_meta) : Cloudwatch::Sender::Fetcher::Custom
         end
 
         def class_namespace(component_meta)


### PR DESCRIPTION
Hello,

this pull request fixes two issues:
- influx_database property is not recognized
- if other metrics like SQS or EC2 of the AWS/\* namespace should be used the custom fetcher is not selected and an exception is thrown. For example for ELB the namespace is AWS/ELB

Greetings,
Rainer
